### PR TITLE
fix: generateimages by openai

### DIFF
--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -122,7 +122,9 @@ class LLMService:
                     logger.error(error_message)
                     raise Exception(error_message)
             elif image_llm_provider == "openai":
-                response = self.image_client.images.generate(
+                if (resolution != None):
+                    resolution = resolution.replace("*", "x")
+                response = self.openai_client.images.generate(
                     model=image_llm_model,
                     prompt=safe_prompt,
                     size=resolution,


### PR DESCRIPTION
FIx bugs:
- Ensure correct resolution parameter format when calling OpenAI image generation API by replacing potential * separator (e.g. 1024*1024) with x (e.g. 1024x1024)
- Fix incorrect client reference from image_client to openai_client